### PR TITLE
Fix for turbolinks loading issue

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -1,14 +1,21 @@
-fitSectionsToWindow = function(){
+var fitSectionsToWindow = function(){
   if ($('section').height() < ($(window).height() * 0.9)){
     $('section').height($(window).height() * 0.9)
   }
 }
 
-$(document).ready(function(){
+var tempNavbarFix = function(){
   if(!Modernizr.mediaqueries){
     $('.navbar-toggle').remove()
     $('.navbar-header').append('<button type="button" class="btn btn-success navbar-btn navbar-right" id="register">Register</button>')
   }
+}
 
+var ready = function(){
+  tempNavbarFix()
   fitSectionsToWindow()
-})
+}
+
+
+$(document).ready(ready)
+$(document).on('page:load', ready)


### PR DESCRIPTION
- apparently jQuery's 'ready' method doesn't fire when using turbolinks. This is because all of the javascript is loaded up right at the beginning and content is the only thing changed subsequently. The fix here is to use turbolinks' page:load event instead.
